### PR TITLE
Register each starter app only once for each user, even when switching apps

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,15 +6,14 @@ import Home from './home';
 const pages = ['home', 'counter', 'trafficlight'] as const;
 type Page = (typeof pages)[number];
 
-function getComponent(page: Page) {
-  switch (page) {
-    case 'home':
-      return <Home />;
-    case 'counter':
-      return <Counter />;
-    case 'trafficlight':
-      return <TrafficLight />;
-  }
+function renderComponents(page: Page) {
+  return (
+    <>
+      <Home show={page === 'home'} />
+      <Counter show={page === 'counter'} />
+      <TrafficLight show={page === 'trafficlight'} />
+    </>
+  );
 }
 
 function getPage() {
@@ -58,7 +57,7 @@ export default function App() {
           ))}
         </div>
       </div>
-      {getComponent(page)}
+      {renderComponents(page)}
     </div>
   );
 }

--- a/src/examples/counter.tsx
+++ b/src/examples/counter.tsx
@@ -6,7 +6,7 @@ import { skyConfig } from './counter.sky';
 
 const url = 'https://sky.stately.ai/Wu5gAj';
 
-export default function Counter() {
+export default function Counter({ show }: { show: boolean }) {
   // Try opening the app in multiple tabs to see the count change
   const [numberOfPlayers, setNumberOfPlayers] = useState(0);
 
@@ -27,6 +27,10 @@ export default function Counter() {
     },
     skyConfig,
   );
+
+  if (!show) {
+    return null;
+  }
 
   if (sky.isConnecting) {
     return <p>Connecting to Stately Sky...</p>;

--- a/src/examples/trafficLight/trafficLight.tsx
+++ b/src/examples/trafficLight/trafficLight.tsx
@@ -8,7 +8,7 @@ import { skyConfig } from './trafficLight.sky';
 
 const url = 'https://sky.stately.ai/Q9VvW9';
 
-export default function TrafficLight() {
+export default function TrafficLight({ show }: { show: boolean }) {
   // Try opening the app in multiple tabs to see the count change
   const [numberOfPlayers, setNumberOfPlayers] = useState(0);
 
@@ -29,6 +29,10 @@ export default function TrafficLight() {
     },
     skyConfig,
   );
+
+  if (!show) {
+    return null;
+  }
 
   if (sky.isConnecting) {
     return <p>Connecting to Stately Sky...</p>;

--- a/src/home.tsx
+++ b/src/home.tsx
@@ -1,4 +1,8 @@
-export default function Home() {
+export default function Home({ show }: { show: boolean }) {
+  if (!show) {
+    return null;
+  }
+
   return (
     <div className="welcome-text">
       <p>Welcome to the Stately Sky Starter App!</p>


### PR DESCRIPTION
This is a "rendering-only" fix for a minor bug where switching between starter apps re-registers the user as unique.

As a future improvement, we could look into deduping registrations by user at the server level.


The problem

https://github.com/statelyai/sky-starter-app/assets/279239/3c520f6b-a749-459a-a392-4c24e2b68ec9

After this fix


https://github.com/statelyai/sky-starter-app/assets/279239/f2578294-1c4e-40c1-b04c-461a9b49cd53


